### PR TITLE
Mark gfx_macros as a plugin in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx_macros"
 path = "src/lib.rs"
 crate-type = [ "dylib" ]
+plugin = true
 
 [dev_dependencies.gfx]
 git = "https://github.com/gfx-rs/gfx-rs"


### PR DESCRIPTION
This tells cargo to compile the crate for the host when cross-compiling.
